### PR TITLE
Update map_tile_loader_dialog.py

### DIFF
--- a/map_tile_loader_dialog.py
+++ b/map_tile_loader_dialog.py
@@ -63,7 +63,6 @@ dict_sources = {
     "Google Traffic": {"url":"https://mt1.google.com/vt?lyrs=h@159000000,traffic|seconds_into_week:-1&style=3&x={0}&y={1}&z={2}", "zmax":20},
     "Google Satellite": {"url":"https://khms0.google.com/kh/v=923?x={0}&y={1}&z={2}", "zmax":20},
     "Google Hybrid": {"url":"https://mt1.google.com/vt/lyrs=y&x={0}&y={1}&z={2}", "zmax":20},
-    "OSM": {"url":"http://tile.openstreetmap.org/{2}/{0}/{1}.png", "zmax":19},
     "ESRI BaseMap": {"url":"https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{2}/{1}/{0}", "zmax":20},
     "ESRI Terrain": {"url":"https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{2}/{1}/{0}", "zmax":20},
     "ESRI Satellite": {"url":"https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{2}/{1}/{0}", "zmax":20},


### PR DESCRIPTION
Please remove OpenStreetMap. We do not have the resources to allow bulk downloading (rendered on demand). Bulk downloading will likely mean we have to block ALL legitimate use of QGIS.